### PR TITLE
Accept RPC's called on GameManager

### DIFF
--- a/docs/Building-from-source.md
+++ b/docs/Building-from-source.md
@@ -1,6 +1,6 @@
 # Building from source
 
-The solution contains the Impostor server and its dependencies, like Hazel and the plugin API. The server is built using [.NET 7](https://dotnet.microsoft.com/download/dotnet/7.0).
+The solution contains the Impostor server and its dependencies, like Hazel and the plugin API. The server is built using [.NET 8](https://dotnet.microsoft.com/download/dotnet/8.0).
 
 ## Cloning Impostor
 
@@ -14,7 +14,7 @@ git clone https://github.com/Impostor/Impostor.git
 
 ### Dependencies
 
-- [.NET 7 SDK](https://dotnet.microsoft.com/download/dotnet/7.0)
+- [.NET 8 SDK](https://dotnet.microsoft.com/download/dotnet/8.0)
 - [Rider](https://www.jetbrains.com/rider/) or [Visual Studio](https://visualstudio.microsoft.com/vs/) (Optional, only if you want the full IDE experience)
 
 ### Build using the CLI

--- a/docs/Running-the-server.md
+++ b/docs/Running-the-server.md
@@ -16,7 +16,7 @@ Depending on your host you may also need to port forward Impostor to the interne
 
 ## Normal installation
 
-1. Install [.NET 7.0](https://dotnet.microsoft.com/download/dotnet/7.0). We recommend either the ASP.NET Core Runtime or the SDK. The SDK is necessary in case you want to develop Impostor or Impostor plugins.
+1. Install [.NET 8.0](https://dotnet.microsoft.com/download/dotnet/8.0). We recommend either the ASP.NET Core Runtime or the SDK. The SDK is necessary in case you want to develop Impostor or Impostor plugins.
 2. Download the [latest release](https://github.com/Impostor/Impostor/releases) or the [latest CI build](https://nightly.link/Impostor/Impostor/workflows/ci/master). Note that Impostor is built for multiple CPU-architectures and operating systems, you most likely want the x64 version, unless you are running on a Raspberry Pi or another device/VPS with an Arm processor.
 3. Extract the zip.
 4. Modify `config.json` to your liking. Documentation can be found [here](Server-configuration.md). You need to at least change `PublicIp` to the address people will connect to your server to.

--- a/docs/Writing-a-plugin.md
+++ b/docs/Writing-a-plugin.md
@@ -27,17 +27,9 @@ https://dotnet.microsoft.com/download
 
 ## 2. Create a C# project
 
-The first step is creating a new C# project, it must be a **Class Library (.NET Standard)**. The target framework can be any of those compatible with .NET 7, which includes:
-
-- .NET Standard 2.0
-- .NET Standard 2.1
-- .NET 5
-- .NET 6
-- .NET 7
+The first step is creating a new C# project, it must be a **Class Library (.NET Standard)**. The target framework can be any of those compatible with .NET 8, but we recommend sticking with **.NET 8.0**.
 
 For more information about compatibility, see https://docs.microsoft.com/en-us/dotnet/standard/net-standard.
-
-> At the moment of writing this document, I recommend you to use **.NET 7.0**.
 
 When the project has been created, you should have `Class.cs` and `Project.csproj` files. Your `Project.csproj` should look something like this.
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <LangVersion>11</LangVersion>
-    <VersionPrefix>1.9.2</VersionPrefix>
+    <VersionPrefix>1.9.3</VersionPrefix>
     <VersionSuffix>dev</VersionSuffix>
     <EnforceCodeStyleInBuild Condition="$(MSBuildProjectName)!='Hazel'">true</EnforceCodeStyleInBuild>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <LangVersion>11</LangVersion>
-    <VersionPrefix>1.9.1</VersionPrefix>
+    <VersionPrefix>1.9.2</VersionPrefix>
     <VersionSuffix>dev</VersionSuffix>
     <EnforceCodeStyleInBuild Condition="$(MSBuildProjectName)!='Hazel'">true</EnforceCodeStyleInBuild>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>

--- a/src/Impostor.Api/Events/Game/IGameCreatedEvent.cs
+++ b/src/Impostor.Api/Events/Game/IGameCreatedEvent.cs
@@ -1,11 +1,24 @@
 ﻿using Impostor.Api.Games;
+using Impostor.Api.Net;
 
 namespace Impostor.Api.Events
 {
     /// <summary>
     ///     Called whenever a new <see cref="IGame" /> is created.
     /// </summary>
+    /// <remarks>
+    ///     Note that the game just has been created, so no players have joined
+    ///     it yet. If you want to know the future host of this game, use the
+    ///     <see cref="Host"/> property.
+    /// </remarks>
     public interface IGameCreatedEvent : IGameEvent
     {
+        /// <summary>
+        ///     Gets the client that requested creation of the game.
+        /// </summary>
+        /// <remarks>
+        ///     Will be null if game creation was requested by a plugin.
+        /// </remarks>
+        IClient? Host { get; }
     }
 }

--- a/src/Impostor.Server/Events/Game/GameCreatedEvent.cs
+++ b/src/Impostor.Server/Events/Game/GameCreatedEvent.cs
@@ -1,15 +1,19 @@
 ﻿using Impostor.Api.Events;
 using Impostor.Api.Games;
+using Impostor.Api.Net;
 
 namespace Impostor.Server.Events
 {
     public class GameCreatedEvent : IGameCreatedEvent
     {
-        public GameCreatedEvent(IGame game)
+        public GameCreatedEvent(IGame game, IClient? host)
         {
             Game = game;
+            Host = host;
         }
 
         public IGame Game { get; }
+
+        public IClient? Host { get; }
     }
 }

--- a/src/Impostor.Server/Net/Inner/Objects/GameManager/Logic/GameLogicComponent.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/GameManager/Logic/GameLogicComponent.cs
@@ -6,9 +6,9 @@ namespace Impostor.Server.Net.Inner.Objects.GameManager.Logic;
 
 internal abstract class GameLogicComponent
 {
-    public virtual ValueTask HandleRpcAsync(RpcCalls callId, IMessageReader reader)
+    public virtual ValueTask<bool> HandleRpcAsync(RpcCalls callId, IMessageReader reader)
     {
-        throw new NotImplementedException($"Unhandled RpcCall {callId}");
+        return ValueTask.FromResult(false);
     }
 
     public virtual ValueTask<bool> SerializeAsync(IMessageWriter writer, bool initialState)

--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
@@ -591,7 +591,7 @@ namespace Impostor.Server.Net.Inner.Objects
 
             if (sender.Client.Name != name)
             {
-                if (await sender.Client.ReportCheatAsync(RpcCalls.CheckName, CheatCategory.GameFlow, "Client sent name not matching his name from handshake"))
+                if (await sender.Client.ReportCheatAsync(RpcCalls.CheckName, CheatCategory.NameLimits, "Client sent name not matching his name from handshake"))
                 {
                     return false;
                 }
@@ -606,7 +606,7 @@ namespace Impostor.Server.Net.Inner.Objects
         {
             if (Game.GameState == GameStates.Started)
             {
-                if (await sender.Client.ReportCheatAsync(RpcCalls.SetColor, CheatCategory.GameFlow, "Client tried to set a name midgame"))
+                if (await sender.Client.ReportCheatAsync(RpcCalls.SetName, CheatCategory.GameFlow, "Client tried to set a name midgame"))
                 {
                     return false;
                 }
@@ -624,7 +624,7 @@ namespace Impostor.Server.Net.Inner.Objects
 
                 if (sender.Client.Name != name)
                 {
-                    if (await sender.Client.ReportCheatAsync(RpcCalls.SetName, CheatCategory.GameFlow, "Client sent name not matching his name from handshake"))
+                    if (await sender.Client.ReportCheatAsync(RpcCalls.SetName, CheatCategory.NameLimits, "Client sent name not matching his name from handshake"))
                     {
                         return false;
                     }
@@ -655,7 +655,7 @@ namespace Impostor.Server.Net.Inner.Objects
 
                     if (name != expected)
                     {
-                        if (await sender.Client.ReportCheatAsync(RpcCalls.SetName, CheatCategory.GameFlow, "Client sent SetName with incorrect name"))
+                        if (await sender.Client.ReportCheatAsync(RpcCalls.SetName, CheatCategory.NameLimits, "Client sent SetName with incorrect name"))
                         {
                             await SetNameAsync(expected);
                             return false;
@@ -664,7 +664,7 @@ namespace Impostor.Server.Net.Inner.Objects
                 }
                 else
                 {
-                    if (await sender.Client.ReportCheatAsync(RpcCalls.SetName, CheatCategory.GameFlow, $"Client sent {nameof(RpcCalls.SetName)} for a player that didn't request it"))
+                    if (await sender.Client.ReportCheatAsync(RpcCalls.SetName, CheatCategory.NameLimits, $"Client sent {nameof(RpcCalls.SetName)} for a player that didn't request it"))
                     {
                         return false;
                     }

--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
@@ -118,6 +118,11 @@ namespace Impostor.Server.Net.Inner.Objects
                         return false;
                     }
 
+                    if (!await ValidateBroadcast(call, sender, target))
+                    {
+                        return false;
+                    }
+
                     Rpc00PlayAnimation.Deserialize(reader, out var task);
                     break;
                 }
@@ -125,6 +130,11 @@ namespace Impostor.Server.Net.Inner.Objects
                 case RpcCalls.CompleteTask:
                 {
                     if (!await ValidateOwnership(call, sender))
+                    {
+                        return false;
+                    }
+
+                    if (!await ValidateBroadcast(call, sender, target))
                     {
                         return false;
                     }
@@ -263,6 +273,11 @@ namespace Impostor.Server.Net.Inner.Objects
                         return false;
                     }
 
+                    if (!await ValidateBroadcast(call, sender, target))
+                    {
+                        return false;
+                    }
+
                     Rpc11ReportDeadBody.Deserialize(reader, out var targetId);
                     break;
                 }
@@ -270,6 +285,11 @@ namespace Impostor.Server.Net.Inner.Objects
                 case RpcCalls.MurderPlayer:
                 {
                     if (!await ValidateHost(call, sender))
+                    {
+                        return false;
+                    }
+
+                    if (!await ValidateBroadcast(call, sender, target))
                     {
                         return false;
                     }
@@ -285,6 +305,11 @@ namespace Impostor.Server.Net.Inner.Objects
                         return false;
                     }
 
+                    if (!await ValidateBroadcast(call, sender, target))
+                    {
+                        return false;
+                    }
+
                     Rpc13SendChat.Deserialize(reader, out var message);
                     return await HandleSendChat(sender, message);
                 }
@@ -292,6 +317,11 @@ namespace Impostor.Server.Net.Inner.Objects
                 case RpcCalls.StartMeeting:
                 {
                     if (!await ValidateHost(call, sender))
+                    {
+                        return false;
+                    }
+
+                    if (!await ValidateBroadcast(call, sender, target))
                     {
                         return false;
                     }
@@ -308,6 +338,11 @@ namespace Impostor.Server.Net.Inner.Objects
                         return false;
                     }
 
+                    if (!await ValidateBroadcast(call, sender, target))
+                    {
+                        return false;
+                    }
+
                     Rpc15SetScanner.Deserialize(reader, out var on, out var scannerCount);
                     break;
                 }
@@ -315,6 +350,11 @@ namespace Impostor.Server.Net.Inner.Objects
                 case RpcCalls.SendChatNote:
                 {
                     if (!await ValidateOwnership(call, sender))
+                    {
+                        return false;
+                    }
+
+                    if (!await ValidateBroadcast(call, sender, target))
                     {
                         return false;
                     }
@@ -363,6 +403,11 @@ namespace Impostor.Server.Net.Inner.Objects
                         return false;
                     }
 
+                    if (!await ValidateBroadcast(call, sender, target))
+                    {
+                        return false;
+                    }
+
                     // TODO: deserialize and expose the result in an API
                     break;
                 }
@@ -370,6 +415,11 @@ namespace Impostor.Server.Net.Inner.Objects
                 case RpcCalls.SetRole:
                 {
                     if (!await ValidateHost(call, sender))
+                    {
+                        return false;
+                    }
+
+                    if (!await ValidateBroadcast(call, sender, target))
                     {
                         return false;
                     }
@@ -392,6 +442,11 @@ namespace Impostor.Server.Net.Inner.Objects
                         return false;
                     }
 
+                    if (!await ValidateBroadcast(call, sender, target))
+                    {
+                        return false;
+                    }
+
                     Rpc45ProtectPlayer.Deserialize(reader, Game, out var protectTarget, out _);
                     return await HandleProtectPlayer(sender, protectTarget);
                 }
@@ -404,6 +459,11 @@ namespace Impostor.Server.Net.Inner.Objects
                     }
 
                     if (!await ValidateRole(call, sender, PlayerInfo, RoleTypes.Shapeshifter))
+                    {
+                        return false;
+                    }
+
+                    if (!await ValidateBroadcast(call, sender, target))
                     {
                         return false;
                     }
@@ -425,6 +485,11 @@ namespace Impostor.Server.Net.Inner.Objects
                         return false;
                     }
 
+                    if (!await ValidateBroadcast(call, sender, target))
+                    {
+                        return false;
+                    }
+
                     Rpc47CheckMurder.Deserialize(reader, Game, out var murdered);
                     return await HandleCheckMurder(sender, (InnerPlayerControl?)murdered);
                 }
@@ -441,6 +506,12 @@ namespace Impostor.Server.Net.Inner.Objects
                         return false;
                     }
 
+                    if (!await ValidateBroadcast(call, sender, target))
+                    {
+                        return false;
+                    }
+
+                    // CheckProtect should only be passed to Host
                     Rpc48CheckProtect.Deserialize(reader, Game, out _);
                     break;
                 }
@@ -448,6 +519,11 @@ namespace Impostor.Server.Net.Inner.Objects
                 case RpcCalls.CheckZipline:
                 {
                     if (!await ValidateOwnership(call, sender))
+                    {
+                        return false;
+                    }
+
+                    if (!await ValidateCmd(call, sender, target))
                     {
                         return false;
                     }
@@ -485,6 +561,11 @@ namespace Impostor.Server.Net.Inner.Objects
                         return false;
                     }
 
+                    if (!await ValidateCmd(call, sender, target))
+                    {
+                        return false;
+                    }
+
                     Rpc54CheckSpore.Deserialize(reader, out var mushroomId);
                     break;
                 }
@@ -492,6 +573,16 @@ namespace Impostor.Server.Net.Inner.Objects
                 case RpcCalls.CheckShapeshift:
                 {
                     if (!await ValidateOwnership(call, sender))
+                    {
+                        return false;
+                    }
+
+                    if (!await ValidateRole(call, sender, PlayerInfo, RoleTypes.Shapeshifter))
+                    {
+                        return false;
+                    }
+
+                    if (!await ValidateCmd(call, sender ,target))
                     {
                         return false;
                     }

--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
@@ -573,6 +573,14 @@ namespace Impostor.Server.Net.Inner.Objects
 
         private async ValueTask<bool> HandleCheckName(ClientPlayer sender, string name)
         {
+            if (Game.GameState == GameStates.Started)
+            {
+                if (await sender.Client.ReportCheatAsync(RpcCalls.CheckName, CheatCategory.GameFlow, "Client tried to set a name midgame"))
+                {
+                    return false;
+                }
+            }
+
             if (name.Length > 10)
             {
                 if (await sender.Client.ReportCheatAsync(RpcCalls.CheckName, CheatCategory.NameLimits, "Client sent name exceeding 10 characters"))

--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
@@ -180,7 +180,8 @@ namespace Impostor.Server.Net.Inner.Objects
 
                 case RpcCalls.SetName:
                 {
-                    if (!await ValidateHost(call, sender))
+                    if (!await ValidateHost(call, sender) ||
+                        !await ValidateBroadcast(call, sender, target))
                     {
                         return false;
                     }
@@ -202,7 +203,8 @@ namespace Impostor.Server.Net.Inner.Objects
 
                 case RpcCalls.SetColor:
                 {
-                    if (!await ValidateHost(call, sender))
+                    if (!await ValidateHost(call, sender) ||
+                        !await ValidateBroadcast(call, sender, target))
                     {
                         return false;
                     }
@@ -213,7 +215,8 @@ namespace Impostor.Server.Net.Inner.Objects
 
                 case RpcCalls.SetHatStr:
                 {
-                    if (!await ValidateOwnership(call, sender))
+                    if (!await ValidateOwnership(call, sender) ||
+                        !await ValidateBroadcast(call, sender, target))
                     {
                         return false;
                     }
@@ -224,7 +227,8 @@ namespace Impostor.Server.Net.Inner.Objects
 
                 case RpcCalls.SetSkinStr:
                 {
-                    if (!await ValidateOwnership(call, sender))
+                    if (!await ValidateOwnership(call, sender) ||
+                        !await ValidateBroadcast(call, sender, target))
                     {
                         return false;
                     }
@@ -235,7 +239,8 @@ namespace Impostor.Server.Net.Inner.Objects
 
                 case RpcCalls.SetVisorStr:
                 {
-                    if (!await ValidateOwnership(call, sender))
+                    if (!await ValidateOwnership(call, sender) ||
+                        !await ValidateBroadcast(call, sender, target))
                     {
                         return false;
                     }
@@ -257,7 +262,8 @@ namespace Impostor.Server.Net.Inner.Objects
 
                 case RpcCalls.SetLevel:
                 {
-                    if (!await ValidateOwnership(call, sender))
+                    if (!await ValidateOwnership(call, sender) ||
+                        !await ValidateBroadcast(call, sender, target))
                     {
                         return false;
                     }
@@ -365,7 +371,8 @@ namespace Impostor.Server.Net.Inner.Objects
 
                 case RpcCalls.SetPetStr:
                 {
-                    if (!await ValidateOwnership(call, sender))
+                    if (!await ValidateOwnership(call, sender) ||
+                        !await ValidateBroadcast(call, sender, target))
                     {
                         return false;
                     }
@@ -376,7 +383,8 @@ namespace Impostor.Server.Net.Inner.Objects
 
                 case RpcCalls.SetStartCounter:
                 {
-                    if (!await ValidateOwnership(call, sender))
+                    if (!await ValidateOwnership(call, sender) ||
+                        !await ValidateBroadcast(call, sender, target))
                     {
                         return false;
                     }
@@ -387,7 +395,8 @@ namespace Impostor.Server.Net.Inner.Objects
 
                 case RpcCalls.UsePlatform:
                 {
-                    if (!await ValidateOwnership(call, sender))
+                    if (!await ValidateOwnership(call, sender) ||
+                        !await ValidateBroadcast(call, sender, target))
                     {
                         return false;
                     }
@@ -534,7 +543,8 @@ namespace Impostor.Server.Net.Inner.Objects
 
                 case RpcCalls.UseZipline:
                 {
-                    if (!await ValidateHost(call, sender))
+                    if (!await ValidateHost(call, sender) ||
+                        !await ValidateBroadcast(call, sender, target))
                     {
                         return false;
                     }
@@ -545,7 +555,8 @@ namespace Impostor.Server.Net.Inner.Objects
 
                 case RpcCalls.TriggerSpores:
                 {
-                    if (!await ValidateHost(call, sender))
+                    if (!await ValidateHost(call, sender) ||
+                        !await ValidateBroadcast(call, sender, target))
                     {
                         return false;
                     }

--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
@@ -504,7 +504,7 @@ namespace Impostor.Server.Net.Inner.Objects
                         return false;
                     }
 
-                    Rpc46Shapeshift.Deserialize(reader, Game, out var playerControl, out var shouldAnimate);
+                    Rpc55CheckShapeshift.Deserialize(reader, Game, out var playerControl, out var shouldAnimate);
                     break;
                 }
 
@@ -939,7 +939,7 @@ namespace Impostor.Server.Net.Inner.Objects
                 return true;
             }
 
-            if (await ValidateRole(RpcCalls.ProtectPlayer, sender, PlayerInfo, RoleTypes.GuardianAngel))
+            if (!await ValidateRole(RpcCalls.ProtectPlayer, sender, PlayerInfo, RoleTypes.GuardianAngel))
             {
                     return false;
             }

--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
@@ -688,7 +688,7 @@ namespace Impostor.Server.Net.Inner.Objects
 
             if ((byte)color > ColorsCount)
             {
-                if (await sender.Client.ReportCheatAsync(RpcCalls.CheckColor, CheatCategory.ProtocolExtension, "Client sent invalid color"))
+                if (await sender.Client.ReportCheatAsync(RpcCalls.CheckColor, CheatCategory.ColorLimits, "Client sent invalid color"))
                 {
                     return false;
                 }
@@ -736,7 +736,7 @@ namespace Impostor.Server.Net.Inner.Objects
 
                         if (colorOffset == ColorsCount)
                         {
-                            if (await sender.Client.ReportCheatAsync(RpcCalls.SetColor, CheatCategory.GameFlow, "Client sent SetColor but all colors are already in use"))
+                            if (await sender.Client.ReportCheatAsync(RpcCalls.SetColor, CheatCategory.ColorLimits, "Client sent SetColor but all colors are already in use"))
                             {
                                 await SetColorAsync(expected);
                                 return false;
@@ -746,7 +746,7 @@ namespace Impostor.Server.Net.Inner.Objects
 
                     if (color != expected)
                     {
-                        if (await sender.Client.ReportCheatAsync(RpcCalls.SetColor, CheatCategory.GameFlow, "Client sent SetColor with incorrect color"))
+                        if (await sender.Client.ReportCheatAsync(RpcCalls.SetColor, CheatCategory.ColorLimits, "Client sent SetColor with incorrect color"))
                         {
                             await SetColorAsync(expected);
                             return false;

--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
@@ -147,18 +147,6 @@ namespace Impostor.Server.Net.Inner.Objects
                     break;
                 }
 
-                case RpcCalls.SetInfected:
-                {
-                    if (!await ValidateOwnership(call, sender) || !await ValidateHost(call, sender))
-                    {
-                        return false;
-                    }
-
-                    Rpc03SetInfected.Deserialize(reader, out var infectedIds);
-                    await HandleSetInfected(infectedIds);
-                    break;
-                }
-
                 case RpcCalls.CheckName:
                 {
                     if (!await ValidateOwnership(call, sender) ||

--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
@@ -113,12 +113,8 @@ namespace Impostor.Server.Net.Inner.Objects
             {
                 case RpcCalls.PlayAnimation:
                 {
-                    if (!await ValidateOwnership(call, sender))
-                    {
-                        return false;
-                    }
-
-                    if (!await ValidateBroadcast(call, sender, target))
+                    if (!await ValidateOwnership(call, sender) ||
+                        !await ValidateBroadcast(call, sender, target))
                     {
                         return false;
                     }
@@ -129,12 +125,8 @@ namespace Impostor.Server.Net.Inner.Objects
 
                 case RpcCalls.CompleteTask:
                 {
-                    if (!await ValidateOwnership(call, sender))
-                    {
-                        return false;
-                    }
-
-                    if (!await ValidateBroadcast(call, sender, target))
+                    if (!await ValidateOwnership(call, sender) ||
+                        !await ValidateBroadcast(call, sender, target))
                     {
                         return false;
                     }
@@ -169,7 +161,8 @@ namespace Impostor.Server.Net.Inner.Objects
 
                 case RpcCalls.CheckName:
                 {
-                    if (!await ValidateOwnership(call, sender) || !await ValidateCmd(call, sender, target))
+                    if (!await ValidateOwnership(call, sender) ||
+                        !await ValidateCmd(call, sender, target))
                     {
                         return false;
                     }
@@ -192,7 +185,8 @@ namespace Impostor.Server.Net.Inner.Objects
 
                 case RpcCalls.CheckColor:
                 {
-                    if (!await ValidateOwnership(call, sender) || !await ValidateCmd(call, sender, target))
+                    if (!await ValidateOwnership(call, sender) ||
+                        !await ValidateCmd(call, sender, target))
                     {
                         return false;
                     }
@@ -274,12 +268,8 @@ namespace Impostor.Server.Net.Inner.Objects
 
                 case RpcCalls.ReportDeadBody:
                 {
-                    if (!await ValidateOwnership(call, sender))
-                    {
-                        return false;
-                    }
-
-                    if (!await ValidateBroadcast(call, sender, target))
+                    if (!await ValidateOwnership(call, sender) ||
+                        !await ValidateBroadcast(call, sender, target))
                     {
                         return false;
                     }
@@ -290,12 +280,8 @@ namespace Impostor.Server.Net.Inner.Objects
 
                 case RpcCalls.MurderPlayer:
                 {
-                    if (!await ValidateHost(call, sender))
-                    {
-                        return false;
-                    }
-
-                    if (!await ValidateBroadcast(call, sender, target))
+                    if (!await ValidateHost(call, sender) ||
+                        !await ValidateBroadcast(call, sender, target))
                     {
                         return false;
                     }
@@ -306,12 +292,8 @@ namespace Impostor.Server.Net.Inner.Objects
 
                 case RpcCalls.SendChat:
                 {
-                    if (!await ValidateOwnership(call, sender))
-                    {
-                        return false;
-                    }
-
-                    if (!await ValidateBroadcast(call, sender, target))
+                    if (!await ValidateOwnership(call, sender) ||
+                        !await ValidateBroadcast(call, sender, target))
                     {
                         return false;
                     }
@@ -322,12 +304,8 @@ namespace Impostor.Server.Net.Inner.Objects
 
                 case RpcCalls.StartMeeting:
                 {
-                    if (!await ValidateHost(call, sender))
-                    {
-                        return false;
-                    }
-
-                    if (!await ValidateBroadcast(call, sender, target))
+                    if (!await ValidateHost(call, sender) ||
+                        !await ValidateBroadcast(call, sender, target))
                     {
                         return false;
                     }
@@ -339,12 +317,8 @@ namespace Impostor.Server.Net.Inner.Objects
 
                 case RpcCalls.SetScanner:
                 {
-                    if (!await ValidateOwnership(call, sender))
-                    {
-                        return false;
-                    }
-
-                    if (!await ValidateBroadcast(call, sender, target))
+                    if (!await ValidateOwnership(call, sender) ||
+                        !await ValidateBroadcast(call, sender, target))
                     {
                         return false;
                     }
@@ -355,12 +329,8 @@ namespace Impostor.Server.Net.Inner.Objects
 
                 case RpcCalls.SendChatNote:
                 {
-                    if (!await ValidateOwnership(call, sender))
-                    {
-                        return false;
-                    }
-
-                    if (!await ValidateBroadcast(call, sender, target))
+                    if (!await ValidateOwnership(call, sender) ||
+                        !await ValidateBroadcast(call, sender, target))
                     {
                         return false;
                     }
@@ -407,12 +377,8 @@ namespace Impostor.Server.Net.Inner.Objects
 
                 case RpcCalls.SendQuickChat:
                 {
-                    if (!await ValidateOwnership(call, sender))
-                    {
-                        return false;
-                    }
-
-                    if (!await ValidateBroadcast(call, sender, target))
+                    if (!await ValidateOwnership(call, sender) ||
+                        !await ValidateBroadcast(call, sender, target))
                     {
                         return false;
                     }
@@ -423,12 +389,8 @@ namespace Impostor.Server.Net.Inner.Objects
 
                 case RpcCalls.SetRole:
                 {
-                    if (!await ValidateHost(call, sender))
-                    {
-                        return false;
-                    }
-
-                    if (!await ValidateBroadcast(call, sender, target))
+                    if (!await ValidateHost(call, sender) ||
+                        !await ValidateBroadcast(call, sender, target))
                     {
                         return false;
                     }
@@ -446,12 +408,8 @@ namespace Impostor.Server.Net.Inner.Objects
 
                 case RpcCalls.ProtectPlayer:
                 {
-                    if (!await ValidateHost(call, sender))
-                    {
-                        return false;
-                    }
-
-                    if (!await ValidateBroadcast(call, sender, target))
+                    if (!await ValidateHost(call, sender) ||
+                        !await ValidateBroadcast(call, sender, target))
                     {
                         return false;
                     }
@@ -462,17 +420,9 @@ namespace Impostor.Server.Net.Inner.Objects
 
                 case RpcCalls.Shapeshift:
                 {
-                    if (!await ValidateHost(call, sender))
-                    {
-                        return false;
-                    }
-
-                    if (!await ValidateRole(call, sender, PlayerInfo, RoleTypes.Shapeshifter))
-                    {
-                        return false;
-                    }
-
-                    if (!await ValidateBroadcast(call, sender, target))
+                    if (!await ValidateHost(call, sender) ||
+                        !await ValidateRole(call, sender, PlayerInfo, RoleTypes.Shapeshifter) ||
+                        !await ValidateBroadcast(call, sender, target))
                     {
                         return false;
                     }
@@ -484,17 +434,9 @@ namespace Impostor.Server.Net.Inner.Objects
 
                 case RpcCalls.CheckMurder:
                 {
-                    if (!await ValidateOwnership(call, sender))
-                    {
-                        return false;
-                    }
-
-                    if (!await ValidateImpostor(call, sender, PlayerInfo))
-                    {
-                        return false;
-                    }
-
-                    if (!await ValidateBroadcast(call, sender, target))
+                    if (!await ValidateOwnership(call, sender) ||
+                        !await ValidateImpostor(call, sender, PlayerInfo) ||
+                        !await ValidateBroadcast(call, sender, target))
                     {
                         return false;
                     }
@@ -505,34 +447,22 @@ namespace Impostor.Server.Net.Inner.Objects
 
                 case RpcCalls.CheckProtect:
                 {
-                    if (!await ValidateOwnership(call, sender))
+                    if (!await ValidateOwnership(call, sender) ||
+                        !await ValidateRole(call, sender, PlayerInfo, RoleTypes.GuardianAngel) ||
+                        !await ValidateBroadcast(call, sender, target))
                     {
                         return false;
                     }
 
-                    if (!await ValidateRole(call, sender, PlayerInfo, RoleTypes.GuardianAngel))
-                    {
-                        return false;
-                    }
-
-                    if (!await ValidateBroadcast(call, sender, target))
-                    {
-                        return false;
-                    }
-
-                    // CheckProtect should only be passed to Host
+                    // CheckProtect should only be passed to Host and not handled server side
                     Rpc48CheckProtect.Deserialize(reader, Game, out _);
                     break;
                 }
 
                 case RpcCalls.CheckZipline:
                 {
-                    if (!await ValidateOwnership(call, sender))
-                    {
-                        return false;
-                    }
-
-                    if (!await ValidateCmd(call, sender, target))
+                    if (!await ValidateOwnership(call, sender) ||
+                        !await ValidateCmd(call, sender, target))
                     {
                         return false;
                     }
@@ -567,12 +497,8 @@ namespace Impostor.Server.Net.Inner.Objects
 
                 case RpcCalls.CheckSpore:
                 {
-                    if (!await ValidateOwnership(call, sender))
-                    {
-                        return false;
-                    }
-
-                    if (!await ValidateCmd(call, sender, target))
+                    if (!await ValidateOwnership(call, sender) ||
+                        !await ValidateCmd(call, sender, target))
                     {
                         return false;
                     }
@@ -583,17 +509,9 @@ namespace Impostor.Server.Net.Inner.Objects
 
                 case RpcCalls.CheckShapeshift:
                 {
-                    if (!await ValidateOwnership(call, sender))
-                    {
-                        return false;
-                    }
-
-                    if (!await ValidateRole(call, sender, PlayerInfo, RoleTypes.Shapeshifter))
-                    {
-                        return false;
-                    }
-
-                    if (!await ValidateCmd(call, sender ,target))
+                    if (!await ValidateOwnership(call, sender) ||
+                        !await ValidateRole(call, sender, PlayerInfo, RoleTypes.Shapeshifter) ||
+                        !await ValidateCmd(call, sender, target))
                     {
                         return false;
                     }

--- a/src/Impostor.Server/Net/Manager/CompatibilityManager.cs
+++ b/src/Impostor.Server/Net/Manager/CompatibilityManager.cs
@@ -23,6 +23,7 @@ internal class CompatibilityManager : ICompatibilityManager
         new[]
         {
             new GameVersion(2024, 2, 1), // 2024.3.5
+            new GameVersion(2024, 2, 3), // 2024.6.4
         },
     };
 

--- a/src/Impostor.Server/Net/Manager/GameManager.cs
+++ b/src/Impostor.Server/Net/Manager/GameManager.cs
@@ -93,11 +93,11 @@ namespace Impostor.Server.Net.Manager
                 return null;
             }
 
-            var (success, game) = await TryCreateAsync(options, filterOptions, @event.GameCode);
+            var (success, game) = await TryCreateAsync(options, filterOptions, owner, @event.GameCode);
 
             for (var i = 0; i < 10 && !success; i++)
             {
-                (success, game) = await TryCreateAsync(options, filterOptions);
+                (success, game) = await TryCreateAsync(options, filterOptions, owner);
             }
 
             if (!success || game == null)
@@ -113,7 +113,7 @@ namespace Impostor.Server.Net.Manager
             return CreateAsync(null, options, filterOptions);
         }
 
-        private async ValueTask<(bool Success, Game? Game)> TryCreateAsync(IGameOptions options, GameFilterOptions filterOptions, GameCode? desiredGameCode = null)
+        private async ValueTask<(bool Success, Game? Game)> TryCreateAsync(IGameOptions options, GameFilterOptions filterOptions, IClient? owner, GameCode? desiredGameCode = null)
         {
             var gameCode = desiredGameCode ?? _gameCodeFactory.Create();
             var game = ActivatorUtilities.CreateInstance<Game>(_serviceProvider, _publicIp, gameCode, options, filterOptions);
@@ -125,7 +125,7 @@ namespace Impostor.Server.Net.Manager
 
             _logger.LogDebug("Created game with code {0}.", game.Code);
 
-            await _eventManager.CallAsync(new GameCreatedEvent(game));
+            await _eventManager.CallAsync(new GameCreatedEvent(game, owner));
 
             return (true, game);
         }

--- a/src/Impostor.Server/Net/State/Game.Data.cs
+++ b/src/Impostor.Server/Net/State/Game.Data.cs
@@ -230,6 +230,8 @@ namespace Impostor.Server.Net.State
                     {
                         // Sender is only allowed to change his own scene.
                         var clientId = reader.ReadPackedInt32();
+                        var scene = reader.ReadString();
+
                         if (clientId != sender.Client.Id)
                         {
                             _logger.LogWarning(
@@ -239,7 +241,17 @@ namespace Impostor.Server.Net.State
                             return false;
                         }
 
-                        sender.Scene = reader.ReadString();
+                        // According to game assembly, sender is only allowed to send OnlineGame.
+                        if (scene != "OnlineGame")
+                        {
+                            _logger.LogWarning(
+                                "Player {0} ({1}) tried to send SceneChangeFlag with disallowed scene.",
+                                sender.Client.Name,
+                                sender.Client.Id);
+                            return false;
+                        }
+
+                        sender.Scene = scene;
 
                         _logger.LogTrace("> Scene {0} to {1}", clientId, sender.Scene);
                         break;
@@ -248,6 +260,15 @@ namespace Impostor.Server.Net.State
                     case GameDataTag.ReadyFlag:
                     {
                         var clientId = reader.ReadPackedInt32();
+
+                        if (clientId != sender.Client.Id)
+                        {
+                            _logger.LogWarning(
+                                "Player {0} ({1}) tried to send ReadyFlag for another player.",
+                                sender.Client.Name,
+                                sender.Client.Id);
+                        }
+
                         _logger.LogTrace("> IsReady {0}", clientId);
                         break;
                     }

--- a/src/Impostor.Server/Net/State/Game.Data.cs
+++ b/src/Impostor.Server/Net/State/Game.Data.cs
@@ -267,6 +267,7 @@ namespace Impostor.Server.Net.State
                                 "Player {0} ({1}) tried to send ReadyFlag for another player.",
                                 sender.Client.Name,
                                 sender.Client.Id);
+                            return false;
                         }
 
                         _logger.LogTrace("> IsReady {0}", clientId);

--- a/src/Impostor.Server/Net/State/Game.State.cs
+++ b/src/Impostor.Server/Net/State/Game.State.cs
@@ -81,7 +81,7 @@ namespace Impostor.Server.Net.State
                 if (player.Client.Connection.IsConnected && player.Client.Connection is HazelConnection hazel)
                 {
                     _logger.LogInformation("{0} - Player {1} ({2}) kept connection open after leaving, disposing.", Code, player.Client.Name, playerId);
-                    hazel.DisposeInnerConnection();
+                    await player.Client.DisconnectAsync(isBan ? DisconnectReason.Banned : DisconnectReason.Kicked);
                 }
             });
 


### PR DESCRIPTION
Previously Impostor would just throw when a method was called on a GameManager, but this caused issues with client mods that did just this, even through vanilla never calls an RPC on GameManager.

This commit changes that throw statement to pass the exception to the custom message handler/anticheat instead, which is also how it works for the other NetObjects

### Description


<!-- 

If your pull request closes any issues, add them below with the `closes` keyword before them 

Example: closes #101

See the following article for more information: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

-->

### Closes issues

- closes #
