### PR TITLE
Set PlayerLevel in PlayerInfo on RPC SetLevel

### DIFF
--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
@@ -251,7 +251,7 @@ namespace Impostor.Server.Net.Inner.Objects
                     }
 
                     Rpc38SetLevel.Deserialize(reader, out var level);
-                    return true;
+                    return await HandleSetLevel(sender, level);
                 }
 
                 case RpcCalls.ReportDeadBody:
@@ -832,6 +832,20 @@ namespace Impostor.Server.Net.Inner.Objects
             }
 
             PlayerInfo.CurrentOutfit.NamePlateId = skin;
+
+            return true;
+        }
+
+        private async ValueTask<bool> HandleSetLevel(ClientPlayer sender, uint level)
+        {
+            if (Game.GameState == GameStates.Started &&
+                await sender.Client.ReportCheatAsync(RpcCalls.SetLevel, CheatCategory.GameFlow, "Client tried to set level while not in game"))
+            {
+                return false;
+            }
+
+            PlayerInfo.PlayerLevel = level;
+            PlayerInfo.IsDirty = true;
 
             return true;
         }


### PR DESCRIPTION
Previously this used to be done by the host, but this is now the server's responsibility.

### Description


<!-- 

If your pull request closes any issues, add them below with the `closes` keyword before them 

Example: closes #101

See the following article for more information: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

-->

### Closes issues

- closes #
